### PR TITLE
fixed extension manifest file

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "vscode": "^1.18.0"
     },
     "categories": [
-        "Languages",
+        "Programming Languages",
         "Linters",
         "Formatters"
     ],


### PR DESCRIPTION
"Languages" category was changed to "Programming Languages" some time ago:

https://github.com/Microsoft/vscode-docs/commit/b586a9c15530b468865ee6ffdbdb27fe0f1e0a7d