### PR TITLE
change vendor tests exclude pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
                         "**/.DS_Store/**",
                         "**/node_modules/**",
                         "**/bower_components/**",
-                        "**/vendor/**/{Test,test,Tests,tests}/**"
+                        "**/vendor/**/{Test,test,Tests,tests}/**/*Test.php"
                     ],
                     "description": "Configure glob patterns to exclude certain files and folders from all language server features. Inherits from files.exclude.",
                     "scope": "resource"


### PR DESCRIPTION
Fixes #418 and #457 

I am facing these 2 issues, and I propose to change the exclude pattern for vendor tests folder to fix them.

Indeed, according to PHPunit documentation (https://phpunit.readthedocs.io/en/8.2/organizing-tests.html), test files usually ends with`Test.php`.

Feedback would be very appreciated! :wink: 