### PR TITLE
chore: change "intelephense.environment.phpVersion" to 8.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -479,7 +479,7 @@
                 },
                 "intelephense.environment.phpVersion": {
                     "type": "string",
-                    "default": "8.0.0",
+                    "default": "8.1.0",
                     "description": "A semver compatible string that represents the target PHP version. Used for providing version appropriate suggestions and diagnostics. PHP 5.3.0 and greater supported.",
                     "scope": "window"
                 },


### PR DESCRIPTION
Hi, @bmewburn 

The Change Log has `PHP 8.1 is now the default version.` written all over it.

- <https://github.com/bmewburn/vscode-intelephense/blob/master/CHANGELOG.md#180---2021-12-05>

In current `vscode-intelephense`, the default is set to `"8.0.0"`.

```jsonc
                "intelephense.environment.phpVersion": {
                    "type": "string",
                    "default": "8.0.0",
                    "description": "A semver compatible string that represents the target PHP version. Used for providing version appropriate suggestions and diagnostics. PHP 5.3.0 and greater supported.",
                    "scope": "window"
                },
```

It probably means that if you don't pass the `intelephense.environment.phpVersion` setting to the language server itself, you will get 8.1, but just to be sure, I also changed the setting on the extension side

If you have intentionally left the `intelephense.environment.phpVersion` settings at "8.0.0", please close this PR. 🙇