### PR TITLE
Replace couchbase_v3 with couchbase_v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
                             "com_dotnet",
                             "Core",
                             "couchbase",
-                            "couchbase_v3",
+                            "couchbase_v2",
                             "crypto",
                             "ctype",
                             "cubrid",


### PR DESCRIPTION
The `couchbase_v3` option no longer exists in the stubs repo as `v3` is now current. 

`couchbase_v2` has been added as stubs exist for that and `v2` is still in use.