### PR TITLE
Match PHP Language Configuration from VS Code

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -71,7 +71,7 @@ export async function activate(context: ExtensionContext) {
 				previousLineText: /^\s*(((else ?)?if|for(each)?|while)\s*\(.*\)\s*|else\s*)$/,
 				// But make sure line doesn't have braces or is not another if statement
 				beforeText: /^\s+([^{i\s]|i(?!f\b))/,
-				action: { indent: IndentAction.Outdent }
+				action: { indentAction: IndentAction.Outdent }
 			}
 		]
 	});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -65,6 +65,13 @@ export async function activate(context: ExtensionContext) {
 				// e.g.  *-----*/|
 				beforeText: /^(\t|(\ \ ))*\ \*[^/]*\*\/\s*$/,
 				action: { indentAction: IndentAction.None, removeText: 1 }
+			},
+			{
+				// Decrease indentation after single line if/else if/else, for, foreach, or while
+				previousLineText: /^\s*(((else ?)?if|for(each)?|while)\s*\(.*\)\s*|else\s*)$/,
+				// But make sure line doesn't have braces or is not another if statement
+				beforeText: /^\s+([^{i\s]|i(?!f\b))/,
+				action: { indent: IndentAction.Outdent }
 			}
 		]
 	});


### PR DESCRIPTION
In https://github.com/microsoft/vscode/pull/136577, the PHP language configuration was updates to it reduces the indent after a single line `if`, `while`, etc. I copied it over here.