### PR TITLE
fix: add `intelephense` to the prefix of `completion.suggestObjectOperatorStaticMethods` setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -464,7 +464,7 @@
                     "description": "The maximum number of completion items returned per request.",
                     "scope": "window"
                 },
-                "completion.suggestObjectOperatorStaticMethods": {
+                "intelephense.completion.suggestObjectOperatorStaticMethods": {
                     "type": "boolean",
                     "default": true,
                     "description": "PHP permits the calling of static methods using the object operator eg `$obj->myStaticMethod();`. If you would prefer not to have static methods suggested in this context then set this value to `false`. Defaults to `true`.",


### PR DESCRIPTION
The default settings in VSCode were missing the `intelephense` prefix, making it impossible to enable or disable the settings correctly, so I fixed it.

- `completion.suggestObjectOperatorStaticMethods` -> `intelephense.completion.suggestObjectOperatorStaticMethods`