### PR TITLE
The current PHP coding standards are PER-CS, not PER

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 - `$http_response_header` is now type `array|unset`.
 - `$php_errmsg` is now type `string|unset`.
 - Updated stubs.
-- Formatter now aims to be [PER](https://www.php-fig.org/per/coding-style/) compliant. As such, `psr12` setting in `intelephense.format.braces` has been removed and `per` added.
+- Formatter now aims to be [PER-CS](https://www.php-fig.org/per/coding-style/) compliant. As such, `psr12` setting in `intelephense.format.braces` has been removed and `per` added.
 - Formatter now allows a single space or no space in unary logical negation.
 - Empty class, trait, interface, enum, function, method bodies are formatted to `{}` with a single space preceeding `{`.
 - Short anonymous functions are now formatted to have no space between `fn` and `(`.


### PR DESCRIPTION
"PER" stands for "PHP Evolving Recommendation."  The specific PER for coding standards goes by "PER-CS", "PER Coding Standards", or similar.  Just saying "PER" is like saying "PSR" or "RFC". 😄 

It's very likely that there are other places in the code where this error was made, so if someone who actually knows the code can go hunt them down that would be appreciated.  (We've had to correct both php-cs-fixer and JetBrains/IntelliJ on the same thing, so don't feel too bad about it.  I think we're just not doing a good enough job marketing it properly.)

(Disclosure: I'm the current Editor for PER-CS.)