### PR TITLE
fix(environment.phpVersion): consider the project's composer php version 🇧🇷

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "contributes": {
         "languages": [
             {
-                "id": "php"
+                "id": "php",
+                "extensions": [".php"]
             }
         ],
         "commands": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,9 +20,10 @@ import {
 } from 'vscode-languageclient/node';
 import { createMiddleware, IntelephenseMiddleware } from './middleware';
 import * as fs from 'fs-extra';
+import { vscodeLocalSettings } from './phpVersion/vscodeLocalSettings';
 
 const PHP_LANGUAGE_ID = 'php';
-const VERSION = '1.13.1';
+const VERSION = '1.14.1';
 const INDEXING_STARTED_NOTIFICATION = new NotificationType('indexingStarted');
 const INDEXING_ENDED_NOTIFICATION = new NotificationType('indexingEnded');
 const CANCEL_INDEXING_REQUEST = new RequestType('cancelIndexing');
@@ -113,6 +114,11 @@ export async function activate(context: ExtensionContext) {
 	languageClient.start().then(() => {
 		registerNotificationListeners();
 		showStartMessage(context);
+		vscodeLocalSettings(
+			workspace.workspaceFolders
+				? workspace.workspaceFolders[0].uri.fsPath
+				: ''
+		)
 	});
 }
 

--- a/src/phpVersion/syncPhpVersion.ts
+++ b/src/phpVersion/syncPhpVersion.ts
@@ -1,0 +1,56 @@
+import { promises as fs } from 'fs';
+import { exec } from 'child_process';
+
+const REGEX_PHP = /"php"\s*:\s*"[^"]+"/g;
+
+export async function syncPhpVersion(workspaceRoot: string) {
+  const COMPOSER_PATH = workspaceRoot + '/composer.json';
+
+  let phpVersion = '';
+  if (await isFileExists(COMPOSER_PATH)) {
+    const composerFile = await fs.readFile(COMPOSER_PATH, 'utf-8');
+    const matches = composerFile.match(REGEX_PHP);
+
+    if (matches) {
+      phpVersion = matches
+        .map((match) => match.split(':')[1].trim().replace(/"/g, ''))
+        .find(value => value !== undefined)
+        ?.trim() || '';
+    } else {
+      console.log('composer.json found but PHP version is not specified');
+    }
+  }
+
+  if (phpVersion.length > 1) {
+    return phpVersion;
+  }
+
+  phpVersion = await execCommand('php -r "echo PHP_MAJOR_VERSION . \'.\' . PHP_MINOR_VERSION . \'.*\';"');
+
+  if (phpVersion.length < 1) {
+    console.log('unable to get installed PHP version');
+  }
+
+  return phpVersion;
+}
+
+async function isFileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch (error: any) {
+    if (error.code === 'ENOENT') {
+      return false;
+    };
+    throw error;
+  }
+};
+
+async function execCommand(command: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    exec(command, (error, stdout) => {
+      if (error) {reject(error);}
+      else {resolve(stdout.trim());}
+    });
+  });
+}

--- a/src/phpVersion/vscodeLocalSettings.ts
+++ b/src/phpVersion/vscodeLocalSettings.ts
@@ -1,0 +1,33 @@
+import * as fs from 'fs';
+import { syncPhpVersion } from './syncPhpVersion';
+
+export async function vscodeLocalSettings(workspaceRoot: string) {
+  try {
+    const vscodeDir = workspaceRoot + '/.vscode';
+    if (!fs.existsSync(vscodeDir)) {
+      fs.mkdirSync(vscodeDir);
+    }
+
+    const settingsPath = vscodeDir + '/settings.json';
+    const phpVersion = await syncPhpVersion(workspaceRoot);
+
+    if (fs.existsSync(settingsPath)) {
+      const existingSettings = fs.readFileSync(settingsPath, 'utf-8')
+        .replace(
+          /"intelephense\.environment\.phpVersion":\s*"[^\\"]+"/,
+          `"intelephense.environment.phpVersion": "${phpVersion}"`
+        );
+  
+      fs.writeFileSync(settingsPath, existingSettings);
+
+      return;
+    }
+
+    const settings = {"intelephense.environment.phpVersion": phpVersion};
+
+    fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+  } catch (error) {
+    console.error((error as Error).message);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
I encountered the same issue described in the issue https://github.com/bmewburn/vscode-intelephense/issues/1710 and decided to implement a fix/feature to consider the version defined in composer.json or the PHP version installed.

The idea behind this implementation was to add a configuration in the local workspace file `.vscode/settings.json`, using the key `intelephense.environment.phpVersion`, where we can define the specific version for the project.

```json
{
    "intelephense.environment.phpVersion": "^7.4"
}
```

Whenever the extension is activated, the process will check and, if it does not exist, will create the `.vscode` directory to ensure that Intelephense uses the PHP version configured for each project, providing a more accurate and controlled environment.

I will be happy to contribute to the extension and I am open to suggestions for improvements!